### PR TITLE
Revert "build(deps): bump lazy-object-proxy from 1.4.3 to 1.5.2"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 astroid==2.4.2
 autopep8==1.5.4
 isort==5.6.4
-lazy-object-proxy==1.5.2
+lazy-object-proxy==1.4.3
 mccabe==0.6.1
 mysql-connector-python==8.0.22
 prettytable==2.0.0


### PR DESCRIPTION
Reverts adityaruplaha/attendance-manager#5

> astroid 2.4.2 requires lazy-object-proxy==1.4.*, but you'll have lazy-object-proxy 1.5.2 which is incompatible.